### PR TITLE
Fixed playlist background to be transparent again

### DIFF
--- a/user.css
+++ b/user.css
@@ -30,7 +30,7 @@ body {
   color: var(--spice-button);
 }
 .encore-dark-theme {
-  --background-base: var(--spice-button);
+  --background-base: var(--spice-main);
 }
 .gHYQaG, .iaAUvZ {
   /*Fix playlist play button when downloaded from Spicetify Marketplace*/


### PR DESCRIPTION
There is a bug where the playlist background isn't transparent anymore, showing the current colour of the theme as background instead. I fixed this by just changing one variable name.